### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A clean Model Context Protocol (MCP) implementation that enables Claude or any LLM to fetch content from URLs.
 
+<a href="https://glama.ai/mcp/servers/@aelaguiz/mcp-url-fetch">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@aelaguiz/mcp-url-fetch/badge" alt="URL Fetch MCP server" />
+</a>
+
 ## Features
 
 - Fetch content from any URL


### PR DESCRIPTION
This PR adds a badge for the [URL Fetch MCP](https://glama.ai/mcp/servers/@aelaguiz/mcp-url-fetch) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@aelaguiz/mcp-url-fetch">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@aelaguiz/mcp-url-fetch/badge" alt="URL Fetch MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.